### PR TITLE
Add testing dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "a63252b16eba6cdebec4e4936388c90552165a68",
+          "version": null
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "0ff81f2c665b4381f526bd656f8708dd52a9ea2f",
+          "version": "1.2.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -9,12 +9,20 @@ let package = Package(
             name: "Harvey",
             targets: ["Harvey"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "1.2.0")),
+        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "7.0.2"))
+    ],
     targets: [
         .target(
             name: "Harvey",
             dependencies: []),
         .testTarget(
             name: "HarveyTests",
-            dependencies: ["Harvey"]),
+            dependencies: [
+                "Harvey",
+                "Quick",
+                "Nimble"
+            ]),
     ]
 )


### PR DESCRIPTION
This was also a fun one! In `PackageDescriptionV3` to make testing work correctly with SPM you had to do some workaround with environment variables or whatever. Now, in `PackageDescriptionV4`, it's really easy to add testing dependencies (although this is/was poorly documented while I was doing a research).