### PR TITLE
Bump Xcode to 9.3 version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: 9.0
+    version: 9.3
   environment:
     LANG: en_US.UTF-8
     HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Let's see if it `danger-swift` works on Xcode 9.3